### PR TITLE
fix greyed out Group Tabs to Window 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,8 @@ the toolbar and it orders all the tabs in the current window by
 domain. One day I may put some actual design effort into it, but for
 now this is all you get.
 
-[My Usual License](https://www.apache.org/licenses/LICENSE-2.0)
+Uses Apache 2.0 License
+
+```bash
+web-ext build --overwrite-dest
+```

--- a/main.js
+++ b/main.js
@@ -1,315 +1,159 @@
-/* lol */
-
-if (typeof browser == "undefined" && typeof chrome == "object") {
-    console.log('polyfilling chrome lol');
+// main.js — completely rebuilt context‐menu logic
+if (typeof browser === "undefined" && typeof chrome === "object") {
     browser = chrome;
     if (!browser.menus) browser.menus = browser.contextMenus;
     if (!browser.browserAction) browser.browserAction = browser.action;
 }
 
+// Constants
+const CONTEXTS = ["tab"];              // show only in tab right‐click menu
+const ROOT_ID = "group-tabs-window";  // root menu item ID
+let TAB_MAP = {};                     // mapping from menu ID → {tabs, recycle}
+
+// ----- Utility: compare functions -----
 const SCHEMES = [
-        /^(http)s?:$/, /^(file):$/, /^s?(ftp):$/, /^(about):$/, /(.*)/];
-
-function compareSchemes (a, b) {
-    let elems = [a, b].map(x => {
-        let scheme = x.protocol.toLowerCase();
-        let rank   = SCHEMES.findIndex(y => { return scheme.match(y); });
-        return [rank, scheme.match(SCHEMES[rank])[1]];
-    });
-    let cmp = elems[0][0] - elems[1][0];
-    if (cmp == 0) {
-        a = elems[0][1];
-        b = elems[1][1];
-        return a < b ? -1 : a > b ? 1 : 0;
-    }
-    return cmp;
+    /^(http)s?:$/, /^(file):$/, /^s?(ftp):$/, /^(about):$/, /(.*)/
+];
+function compareSchemes(a, b) {
+    const ea = SCHEMES.map((rx, i) => a.protocol.match(rx) ? i : -1).filter(i => i >= 0)[0];
+    const eb = SCHEMES.map((rx, i) => b.protocol.match(rx) ? i : -1).filter(i => i >= 0)[0];
+    if (ea !== eb) return ea - eb;
+    const na = a.protocol.match(SCHEMES[ea])[1];
+    const nb = b.protocol.match(SCHEMES[eb])[1];
+    return na.localeCompare(nb);
 }
-
-function compareDomains (a, b) {
-    let elems = [a, b].map(x => {
-        x = x.hostname.toLowerCase().replace(/^www\d*\./, '');
-        return x.split('.').reverse();
-    });
-
-    while (elems[0].length > 0 || elems[1].length > 0) {
-        let d1 = elems[0].shift() || '';
-        let d2 = elems[1].shift() || '';
-        if (d1 == d2) continue;
-        return d1 < d2 ? -1 : 1;
+function compareDomains(a, b) {
+    const pa = a.hostname.replace(/^www\d*\./, '').toLowerCase().split('.').reverse();
+    const pb = b.hostname.replace(/^www\d*\./, '').toLowerCase().split('.').reverse();
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const da = pa[i] || '';
+        const db = pb[i] || '';
+        if (da !== db) return da < db ? -1 : 1;
     }
-
     return 0;
 }
-
-function compareLocal (a, b) {
-    let elems = [a, b].map(x => {
-        return x.pathname + x.search + x.hash;
-    });
-    a = elems[0];
-    b = elems[1];
-    return a < b ? -1 : a > b ? 1 : 0;
+function compareLocal(a, b) {
+    const sa = a.pathname + a.search + a.hash;
+    const sb = b.pathname + b.search + b.hash;
+    return sa.localeCompare(sb);
 }
-
-function compareURIs (a, b) {
+function compareURIs(a, b) {
     if (!(a instanceof URL)) a = new URL(a);
     if (!(b instanceof URL)) b = new URL(b);
-
-    // console.debug(`${a} <=> ${b}`);
-
     let cmp = compareSchemes(a, b);
-    if (cmp === 0) {
-        cmp = compareDomains(a, b);
-        if (cmp === 0) cmp = compareLocal(a, b);
-    }
-    // console.debug(`${a} ${cmp < 0 ? '<' : cmp > 0 ? '>' : '='} ${b}`);
+    if (cmp === 0) cmp = compareDomains(a, b);
+    if (cmp === 0) cmp = compareLocal(a, b);
     return cmp;
 }
-
-function compareTabs (a, b) {
-    // note the inversion here is deliberate
-    let ap = a.pinned ? 0 : 1;
-    let bp = b.pinned ? 0 : 1;
-    // pinned tabs always come before unpinned tabs
-    let cmp = ap - bp;
-    if (cmp === 0) {
-        cmp = compareURIs(a.url, b.url);
-        if (cmp === 0) {
-            // we want this reversed
-            cmp = b.lastAccessed - a.lastAccessed;
-        }
-    }
-
-    return cmp;
+function compareTabs(a, b) {
+    const pa = a.pinned ? 0 : 1;
+    const pb = b.pinned ? 0 : 1;
+    if (pa !== pb) return pa - pb;
+    let cmp = compareURIs(a.url, b.url);
+    if (cmp !== 0) return cmp;
+    return b.lastAccessed - a.lastAccessed;
 }
 
-function moveTabs (id, spec, fn) {
-    if (browser.tabs.move.length == 1) {
-        let p = browser.tabs.move(id, spec);
-        return fn ? p.then(fn) : p;
-    }
-    return browser.tabs.move(id, spec, fn || function () {});
-}
-
-function getTabs (spec, func) {
-    if (browser.tabs.query.length == 1)
-        return browser.tabs.query(spec).then(func);
-    return browser.tabs.query(spec, func);
-}
-
-function sortTabsByDomain (tab) {
-    browser.storage.sync.get('pinned-tabs').then(p => {
-        p = typeof p['pinned-tabs'] === 'undefined' ? true : p['pinned-tabs'];
-
-        let mt = t => {
-            t.sort(compareTabs);
-            for (let i = 0; i < t.length; i++) {
-                if (t[i].pinned && !p) continue;
-                moveTabs(t[i].id, { index: i });
-            }
-        };
-
-        getTabs({ currentWindow: true }, mt);
-    });
-}
-
-
-browser.browserAction.onClicked.addListener(sortTabsByDomain);
-
-/* Here is all the crap to do with Tabs To New Window */
-
-// This function is a noop for now
-function menuCreated (m) {
-    if (typeof m !== 'undefined') console.log(m);
-}
-
-// This structure maps menu item IDs to sets of tabs. It is referenced
-// when a menu item is clicked, and it is torn down and repopulated
-// every time the menu is refreshed.
-const TAB_MAP = {};
-
-const CONTEXTS = ['tab'];
-
-// This is a dispatch table that refines browser.menus.onShown by
-// mapping menu item IDs to handler functions which are proxied by
-// the main event listener.
-const SHOWN = {
-    // The root menu item is currently the only one with a handler.
-    // This function ensures that the menu is only available for tabs
-    // with URIs that have hostnames (for now, a scope constraint). It
-    // also wipes and regenerates the submenus and the state object
-    // used to inform any subsequent click action.
-    ttnw: async function (info, tab) {
-
-        // first order of business is to wipe out the submenus and the
-        // contents of the state object
-        for (let tm in TAB_MAP) {
-            await browser.menus.remove(tm);
-            delete TAB_MAP[tm];
-        }
-
-        // parse the URI to make it useful
-        let url = new URL(tab.url);
-        if (url.hostname !== '') {
-            // process the domain name and split it into individual labels
-            let d  = url.hostname.toLowerCase().replace(/^www\d*\.+/, '');
-            let dl = d.split(/\.+/);
-
-            //console.log(info, dl);
-
-            // obtain the IDs of the tabs in this window
-            let ids = (await browser.tabs.query({
-                windowId: tab.windowId, pinned: false })).map(
-                    t => t.id).filter((e, i, a) => a.indexOf(e) === i).sort(
-                        (a, b) => a < b ? -1 : a > b ? 1 : 0);
-            //console.log(ids);
-
-            // create a submenu item for each successively broader
-            // match on the domain name; the label also matches the
-            // query mask (also this is why i don't feel like
-            // supporting arbitrary URI schemes for now: the query
-            // filter is limited.)
-            let enable = false;
-            for (let i = 0; i < dl.length; i++) {
-                let base = `ttnw-${i+1}`;
-                let mask = `*.${dl.slice(i).join('.')}`;
-                let mine = []; // tabs in this window
-                let othr = []; // tabs in other windows
-                let tabs = (await browser.tabs.query({
-                    url: `*://${mask}/*`, pinned: false })).sort(compareTabs);
-                // pinned tabs are unconditionally verboten since
-                // people put them where they are for a reason
-
-                // unfortunately you can't do this in the query but
-                // you can't move tabs between private and non-private
-                // windows so we filter them here
-                tabs = tabs.filter(t => {
-                    return t.incognito === tab.incognito; });
-
-                // find the subset of tabs which are(n't) in this window
-                tabs.map(t => {
-                    (t.windowId === tab.windowId ? mine : othr).push(t); });
-
-                // recycle the window if all the tabs are on this window
-                let recycle = mine.length == ids.length &&
-                    mine.every(t => ids.indexOf(t.id) >= 0);
-                let variants = !recycle && othr.length > 0;
-
-                //console.log(base, recycle);
-
-                // append the number of objects to the title
-                let title = mask + (variants ? '' : ` (${tabs.length})`);
-
-
-                // skip if no-op
-                if (recycle && othr.length == 0) continue;
-
-                enable = true;
-
-                await browser.menus.create({
-                    id: base, parentId: 'ttnw', title: title,
-                    contexts: CONTEXTS });
-
-                if (variants) {
-                    TAB_MAP[base] = {};
-
-                    let v = {
-                        current: [mine, 'From This Window Only'],
-                        all: [tabs, 'From All Windows']
-                    };
-
-                    for (let j in v) {
-                        let subid = `${base}-${j}`;
-                        TAB_MAP[subid] = { recycle: false, tabs: v[j][0] };
-                        let subtitle = v[j][1] + ` (${v[j][0].length})`;
-                        await browser.menus.create({
-                            id: subid,
-                            parentId: base, title: subtitle,
-                            contexts: CONTEXTS });
-                    }
-                }
-                else {
-                    TAB_MAP[base] = { recycle: recycle, tabs: tabs };
-                }
-                //console.log(tabs);
-            }
-
-            if (enable) await browser.menus.update('ttnw', { enabled: true });
-        }
-        await browser.menus.refresh();
-    }
-};
-
-// add the root menu
-
-
-browser.menus.create({
-    id: "ttnw",
-    title: 'Group Tabs to Window',
-    //contexts: ["page", "tab"]
-    contexts: CONTEXTS
-}, menuCreated);
-
-// add the listeners
-
-// if (browser.menus.onHidden) browser.menus.onHidden.addListener(
-//     async function () {
-//         await browser.menus.update('ttnw', { enabled: false });
-//     });
-
-function tabWTF(info, tab) {
-    let id = info.menuIds[0];
-    if (SHOWN[id]) SHOWN[id](info, tab);
-}
-
-if (browser.menus.onShown) browser.menus.onShown.addListener(tabWTF);
-else {
-    // do the chrome thing
-
-    // we may not need to look at web navigation
-
-    /* browser.webNavigation.onCommitted.addListener(() => {
-    }); */
-
-    // tabs we just need onUpdated because onCreated may fire before
-    // the url is set; we will definitely still need onRemoved though
-
-    // let whatever = function (tab) {};
-
-    // browser.tabs.onUpdated.addListener(whatever);
-    // note this has a different argspec because of course it does
-    // browser.tabs.onRemoved.addListener(whatever);
-}
-
-browser.menus.onClicked.addListener(async function (info, tab) {
-    // obtain the list of tabs and whether to recycle the window
-    let id      = info.menuItemId;
-
-    // fucking chrome
-    if (!TAB_MAP[id]) SHOWN[info.menuIds[0]](info, tab);
-    else console.log(info, TAB_MAP[id]);
-
-    let recycle = TAB_MAP[id].recycle;
-    let targets = TAB_MAP[id].tabs;
-
-    if (targets && targets.length > 0) {
-
-        let win;
-        if (recycle) {
-            win = await browser.windows.get(tab.windowId);
-        }
-        else {
-            let t = targets[0].id;
-            await browser.tabs.reload(t);
-            win = await browser.windows.create({ tabId: t });
-        }
-
-        // get the highest index of the target window
-        let max = (await browser.tabs.query({ windowId: win.id })).reduce(
-            (a, b) => { return a.index > b.index ? a : b; }, -1).index + 1;
-        console.log(`next window position is ${max}`);
-
-        // now move the remaining tabs
-        targets.map((t, i) => {
-            browser.tabs.move(t.id, { windowId: win.id, index: max + i }); });
+// ----- Toolbar button: sort tabs by domain in current window -----
+browser.browserAction.onClicked.addListener(async () => {
+    const { 'pinned-tabs': keepPinned = true } = await browser.storage.sync.get('pinned-tabs');
+    const tabs = await browser.tabs.query({ currentWindow: true });
+    tabs.sort(compareTabs);
+    for (let i = 0; i < tabs.length; i++) {
+        if (tabs[i].pinned && !keepPinned) continue;
+        await browser.tabs.move(tabs[i].id, { index: i });
     }
 });
+
+// ----- Context menu: show dynamic submenu on tab right‐click -----
+browser.menus.onShown.addListener(async (info, tab) => {
+    // remove all old items (root will be recreated below)
+    await browser.menus.removeAll();
+    TAB_MAP = {};
+
+    // recreate the root menu item
+    await browser.menus.create({
+        id: ROOT_ID,
+        title: 'Group Tabs to Window',
+        contexts: CONTEXTS
+    });
+
+    // determine hostname of the clicked tab
+    let host;
+    try {
+        host = new URL(tab.url).hostname.replace(/^www\d*\./, '').toLowerCase();
+    } catch {
+        await browser.menus.refresh();
+        return;
+    }
+
+    // split into labels for progressive domain matching
+    const parts = host.split('.');
+    for (let i = 0; i < parts.length; i++) {
+        const domain = parts.slice(i).join('.');
+        const queryMask = `*.${domain}`;                  // always wildcard for query
+        const displayLabel = (i === 0) ? domain : queryMask;
+        const menuId = `group-${i}`;
+
+        // find matching tabs (naked + subdomains)
+        let tabs = await browser.tabs.query({ url: `*://${queryMask}/*`, pinned: false });
+        tabs = tabs.filter(t => t.incognito === tab.incognito);
+        if (tabs.length === 0) continue;
+
+        // split into this-window vs other-windows
+        const mine = tabs.filter(t => t.windowId === tab.windowId);
+        const othr = tabs.filter(t => t.windowId !== tab.windowId);
+        const recycle = (mine.length === tabs.length);
+
+        // add to map
+        TAB_MAP[menuId] = { tabs, recycle };
+
+        // create submenu entry
+        await browser.menus.create({
+            id: menuId,
+            parentId: ROOT_ID,
+            title: `${displayLabel} (${tabs.length})`,
+            contexts: CONTEXTS
+        });
+
+        // if there are tabs in other windows, add children
+        if (othr.length > 0) {
+            const curId = `${menuId}-cur`;
+            TAB_MAP[curId] = { tabs: mine, recycle: true };
+            await browser.menus.create({
+                id: curId,
+                parentId: menuId,
+                title: `This Window Only (${mine.length})`,
+                contexts: CONTEXTS
+            });
+
+            const allId = `${menuId}-all`;
+            TAB_MAP[allId] = { tabs, recycle: false };
+            await browser.menus.create({
+                id: allId,
+                parentId: menuId,
+                title: `From All Windows (${tabs.length})`,
+                contexts: CONTEXTS
+            });
+        }
+    }
+
+    // finally, refresh to show new menu
+    await browser.menus.refresh();
+});
+
+// ----- Handle menu clicks -----
+browser.menus.onClicked.addListener(async (info, tab) => {
+    const entry = TAB_MAP[info.menuItemId];
+    if (!entry) return;
+
+    const tabs = entry.tabs.sort(compareTabs);
+    // open the first tab in a brand-new window
+    const win = await browser.windows.create({ tabId: tabs[0].id });
+    // move the rest into it
+    for (let i = 1; i < tabs.length; i++) {
+        await browser.tabs.move(tabs[i].id, { windowId: win.id, index: -1 });
+    }
+});
+  
+  

--- a/main.js
+++ b/main.js
@@ -127,7 +127,7 @@ function menuCreated (m) {
 // every time the menu is refreshed.
 const TAB_MAP = {};
 
-const CONTEXTS = ['all', 'page', 'action']; // 'tab'
+const CONTEXTS = ['tab'];
 
 // This is a dispatch table that refines browser.menus.onShown by
 // mapping menu item IDs to handler functions which are proxied by
@@ -251,10 +251,10 @@ browser.menus.create({
 
 // add the listeners
 
-if (browser.menus.onHidden) browser.menus.onHidden.addListener(
-    async function () {
-        await browser.menus.update('ttnw', { enabled: false });
-    });
+// if (browser.menus.onHidden) browser.menus.onHidden.addListener(
+//     async function () {
+//         await browser.menus.update('ttnw', { enabled: false });
+//     });
 
 function tabWTF(info, tab) {
     let id = info.menuIds[0];

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,9 @@
 {
     "manifest_version": 2,
-    "name": "Order Tabs by Domain",
-    "version": "0.2.3",
-    "description": "Tabs ordered by domain, as god intended.",
-    "homepage_url": "https://github.com/doriantaylor/w3x-taborder",
-    "applications": {
-        "gecko": {
-            "id": "{99d1b038-84d5-4cf3-a785-9dad767ca337}"
-        }
-    },
+    "name": "Order Tabs by Domain 2.0",
+    "version": "2.0.0",
+    "description": "Tabs ordered by domain, as the Flying Spaghetti Monster intended. Ramen.",
+    "homepage_url": "https://github.com/jpfleischer/w3x-taborder",
     "icons": {
         "16": "icons/tab-16.png",
         "32": "icons/tab-32.png",
@@ -35,6 +30,6 @@
             "64": "icons/tab-64.png",
             "96": "icons/tab-96.png"
         },
-        "default_title": "Order Tabs by Domain"
+        "default_title": "Order Tabs by Domain 2.0"
     }
 }


### PR DESCRIPTION
Removed the onHidden handler that was permanently disabling the menu item after first use.

Users expect to be able to group tabs multiple times without reloading the extension, and this safety‐switch listener is no longer necessary now that onShown rebuilds/enables correctly.

fixes #8 